### PR TITLE
Keep 'Boiling' switch on while in keep-warm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ Note: At the moment, this integration supports only Smarter Kettle V3, as that i
 **This component will set up the following entities.**
 
 
-| Platform        | Entity             | Description                                                                          |
-| --------------- | ------------------ | ------------------------------------------------------------------------------------ |
-| `binary_sensor` | Boiling            | `On` if kettle is currently heating water                                            |
-| `binary_sensor` | Cooling            | `On` if kettle has warmed water and is allowing it to cool, such as for formula mode |
-| `binary_sensor` | Keeping Warm       | `On` if kettle has warmed water and will keep it warm                                |
-| `sensor`        | Water Temperature  | Current temperature of water                                                         |
-| `sensor`        | Boil Temperature   | Temperature for the next "boil" command                                              |
-| `sensor`        | Target Temperature | Current target temperature <sup>1</sup>                                              |
-| `sensor`        | State              | Current state of Kettle as reported by the API                                       |
-| `sensor`        | Kettle is Present  | Whether the kettle is on the base                                                    |
-| `sensor`        | Water Level        | Current water level <sup>2</sup>                                                     |
-| `switch`        | Boiling            | Set `On` to boil to target temperature. Set `Off` to turn off boiling / keep-warm    |
-| `number`        | Boil Temperature   | Same as the sensor, but allows setting                                               |
-| `number`        | Keep Warm Time     | Allows you to set the time for which kettle will continue to heat water              |
+| Platform        | Entity             | Description                                                                                                                         |
+| --------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `binary_sensor` | Boiling            | `On` if kettle is currently heating water                                                                                           |
+| `binary_sensor` | Cooling            | `On` if kettle has warmed water and is allowing it to cool, such as for formula mode                                                |
+| `binary_sensor` | Keeping Warm       | `On` if kettle has warmed water and will keep it warm                                                                               |
+| `sensor`        | Water Temperature  | Current temperature of water                                                                                                        |
+| `sensor`        | Boil Temperature   | Temperature for the next "boil" command                                                                                             |
+| `sensor`        | Target Temperature | Current target temperature <sup>1</sup>                                                                                             |
+| `sensor`        | State              | Current state of Kettle as reported by the API                                                                                      |
+| `sensor`        | Kettle is Present  | Whether the kettle is on the base                                                                                                   |
+| `sensor`        | Water Level        | Current water level <sup>2</sup>                                                                                                    |
+| `switch`        | Boiling            | Set `On` to boil to target temperature. Set `Off` to turn off boiling / keep-warm. State will remain `On` while keep-warm is active |
+| `number`        | Boil Temperature   | Same as the sensor, but allows setting                                                                                              |
+| `number`        | Keep Warm Time     | Allows you to set the time for which kettle will continue to heat water                                                             |
 
 
 Notes:

--- a/custom_components/smarter/switch.py
+++ b/custom_components/smarter/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, List
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -16,11 +16,11 @@ from .const import DOMAIN
 from .entity import SmarterEntity
 
 
-def make_check_status(key: str, value: Any) -> bool:
+def make_check_status(key: str, values: List[Any]) -> bool:
     """Return a function that checks the status of a device."""
 
     def _check_status(device: BaseDevice) -> bool:
-        return device.device.status.get(key) == value
+        return device.device.status.get(key) in values
 
     return _check_status
 
@@ -45,7 +45,7 @@ SWITCH_TYPES = [
     SmarterSwitchEntityDescription(
         key="start_boil",
         name="Boiling",
-        get_fn=make_check_status("state", "Boiling"),
+        get_fn=make_check_status("state", ["Boiling", "Keeping Warm", "Cooling"]),
         set_fn=set_boil,
         icon="mdi:kettle-steam",
     ),


### PR DESCRIPTION
New Feature: Report switch state as "On" while keeping warm.

This seems partly counter-intuitive, but it does provide an easy way to turn off Keep Warm, both manually and through automation. May change in the future, as this becomes a more stable integration