### PR TITLE
Change reference from Config to ConfigType

### DIFF
--- a/custom_components/smarter/__init__.py
+++ b/custom_components/smarter/__init__.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 
 from custom_components.smarter.smarter_hub import SmarterHub
 
@@ -38,7 +39,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def async_setup(hass: HomeAssistant, config: Config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up this integration using YAML is not supported."""
     return True
 

--- a/custom_components/smarter/manifest.json
+++ b/custom_components/smarter/manifest.json
@@ -17,6 +17,6 @@
     "smarter-client==0.2.4"
   ],
   "ssdp": [],
-  "version": "0.3.1-dev.4",
+  "version": "0.3.1",
   "zeroconf": []
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "homeassistant-smarter"
-version = "0.3.1-dev.4"
+version = "0.3.1"
 description = "Default template for PDM package"
 authors = [{ name = "Kirill Birger", email = "kbirger@gmail.com" }]
 dependencies = ["smarter-client>=0.2.4", "homeassistant>=2024.9.2"]


### PR DESCRIPTION
as recommended by https://developers.home-assistant.io/blog/2024/10/31/core-config-moved/
should fix the following error:
![image](https://github.com/user-attachments/assets/efe28364-1656-404d-b3a8-4e9675e4a84e)
